### PR TITLE
fix profit calculation to exclude new deposits

### DIFF
--- a/src/steth/scWETH.sol
+++ b/src/steth/scWETH.sol
@@ -361,7 +361,7 @@ contract scWETH is sc4626, IFlashLoanRecipient {
         totalInvested += amount;
 
         // when deleveraging, withdraw extra to cover slippage
-        if (!isDeposit) amount = flashLoanAmount.mulWadDown(C.ONE - slippageTolerance);
+        if (!isDeposit) amount += flashLoanAmount.mulWadDown(C.ONE - slippageTolerance);
 
         // take flashloan
         balancerVault.flashLoan(address(this), tokens, amounts, abi.encode(isDeposit, amount));

--- a/src/steth/scWETH.sol
+++ b/src/steth/scWETH.sol
@@ -134,11 +134,11 @@ contract scWETH is sc4626, IFlashLoanRecipient {
     /// @dev reduces the getLtv() back to the target ltv
     /// @dev also mints performance fee tokens to the treasury
     function harvest() external onlyKeeper {
-        // store the old total
-        uint256 oldTotalInvested = totalInvested;
-
         // reinvest
         _rebalancePosition();
+
+        // store the old total
+        uint256 oldTotalInvested = totalInvested;
 
         totalInvested = totalAssets();
 

--- a/src/steth/scWETH.sol
+++ b/src/steth/scWETH.sol
@@ -376,6 +376,9 @@ contract scWETH is sc4626, IFlashLoanRecipient {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = flashLoanAmount;
 
+        // needed otherwise counted as loss during harvest
+        totalInvested -= amount;
+
         // take flashloan
         balancerVault.flashLoan(address(this), tokens, amounts, abi.encode(false, amount));
     }
@@ -413,9 +416,6 @@ contract scWETH is sc4626, IFlashLoanRecipient {
         }
 
         uint256 missing = (assets - float);
-
-        // needed otherwise counted as loss during harvest
-        totalInvested -= missing;
 
         _withdrawToVault(missing);
     }

--- a/src/steth/scWETH.sol
+++ b/src/steth/scWETH.sol
@@ -360,6 +360,9 @@ contract scWETH is sc4626, IFlashLoanRecipient {
         // needed otherwise counted as profit during harvest
         totalInvested += amount;
 
+        // when deleveraging, withdraw extra to cover slippage
+        if (!isDeposit) amount = flashLoanAmount.mulWadDown(C.ONE - slippageTolerance);
+
         // take flashloan
         balancerVault.flashLoan(address(this), tokens, amounts, abi.encode(isDeposit, amount));
     }

--- a/src/steth/scWETH.sol
+++ b/src/steth/scWETH.sol
@@ -139,12 +139,13 @@ contract scWETH is sc4626, IFlashLoanRecipient {
 
         // store the old total
         uint256 oldTotalInvested = totalInvested;
+        uint256 assets = totalAssets();
 
-        totalInvested = totalAssets();
+        if (assets > oldTotalInvested) {
+            totalInvested = assets;
 
-        if (totalInvested > oldTotalInvested) {
             // profit since last harvest, zero if there was a loss
-            uint256 profit = totalInvested - oldTotalInvested;
+            uint256 profit = assets - oldTotalInvested;
             totalProfit += profit;
 
             uint256 fee = profit.mulWadDown(performanceFee);

--- a/test/scWETH.t.sol
+++ b/test/scWETH.t.sol
@@ -577,6 +577,39 @@ contract scWETHTest is Test {
         assertEq(vault.totalProfit(), 0, "profit must be zero");
     }
 
+    function test_disinvest_invest_should_not_increase_invested(uint256 amount) public {
+        vault.setTreasury(treasury);
+        amount = bound(amount, boundMinimum, 1e21);
+        _depositToVault(address(this), amount);
+
+        vm.prank(keeper);
+        vault.harvest();
+
+        assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+        assertEq(vault.totalProfit(), 0, "profit must be zero");
+
+        _depositToVault(alice, amount);
+
+        vm.prank(keeper);
+        vault.harvest();
+
+        assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+        assertEq(vault.totalProfit(), 0, "profit must be zero");
+
+        vm.startPrank(keeper);
+        uint256 all = vault.totalInvested();
+        vault.withdrawToVault(all);
+        vault.depositIntoStrategy();
+        assertApproxEqRel(all, vault.totalInvested(), 0.01e18);
+
+        all = vault.totalInvested();
+        vault.withdrawToVault(all);
+        vault.harvest();
+        assertApproxEqRel(all, vault.totalInvested(), 0.01e18);
+        assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+        assertEq(vault.totalProfit(), 0, "profit must be zero");
+    }
+
     // harvest should never count new deposits as profit
     function test_deposit_profit_deposit_harvest(uint256 amount) public {
         vault.setTreasury(treasury);

--- a/test/scWETH.t.sol
+++ b/test/scWETH.t.sol
@@ -557,6 +557,86 @@ contract scWETHTest is Test {
         assertEq(weth.balanceOf(address(vault)), amount, "weth not transferred to vault");
     }
 
+    function test_deposit_rebalance_deposit_rebalance() public {
+        vault.setTreasury(treasury);
+        uint256 amount = 100 ether;
+        _depositToVault(address(this), amount);
+
+        vm.prank(keeper);
+        vault.harvest();
+
+        assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+
+        _depositToVault(alice, amount);
+
+        vm.prank(keeper);
+        vault.harvest();
+
+        assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+    }
+
+    // harvest should never count new deposits as profit
+    function test_deposit_profit_deposit_harvest(uint256 amount) public {
+        vault.setTreasury(treasury);
+        amount = bound(amount, boundMinimum, 1e20);
+        _depositToVault(address(this), amount);
+
+        vm.prank(keeper);
+        vault.harvest();
+
+        assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+        assertEq(vault.totalProfit(), 0, "profit must be zero");
+
+        uint256 invested = vault.totalAssets();
+        _simulate_stEthStakingInterest(365 days, 1.071e18);
+        uint256 profit = vault.totalAssets() - invested;
+        console.log("vault.totalProfit()", vault.totalProfit());
+        console.log("profit", profit);
+        _depositToVault(alice, amount);
+        vm.prank(keeper);
+        vault.harvest();
+
+        // new deposits should not increase profits
+        assertGt(profit, vault.totalProfit());
+    }
+
+    function test_deposit_rebalance_deposit_rebalance_withSimulatedProfits() public {
+        vault.setTreasury(treasury);
+        uint256 deposit1 = 10 ether;
+        uint256 deposit2 = deposit1 * 10;
+        uint256 deposit3 = deposit1 * 50;
+        _depositToVault(address(this), deposit1);
+
+        vm.prank(keeper);
+        vault.harvest();
+
+        _simulate_stEthStakingInterest(365 days, 1.071e18);
+
+        _depositToVault(alice, deposit2);
+        uint256 slippage = vault.totalAssets();
+
+        vm.prank(keeper);
+        vault.harvest();
+        slippage -= vault.totalAssets();
+
+        uint256 profit1 = vault.totalProfit();
+
+        assertApproxEqRel(profit1, deposit1.mulWadDown(0.15e18) - slippage, 0.1e18);
+
+        _simulate_stEthStakingInterest(365 days, 1.071e18);
+        _depositToVault(address(this), deposit3);
+        slippage = vault.totalAssets();
+
+        vm.prank(keeper);
+        vault.harvest();
+        slippage -= vault.totalAssets();
+
+        assertApproxEqRel(vault.totalProfit(), (vault.totalAssets() - deposit1 - deposit2 - deposit3), 0.01e18);
+        assertApproxEqRel(
+            vault.totalProfit(), profit1 + (profit1 + deposit1 + deposit2).mulWadDown(0.15e18) - slippage, 0.01e18
+        );
+    }
+
     //////////////////////////// INTERNAL METHODS ////////////////////////////////////////
 
     function _createDefaultWethVaultConstructorParams() internal view returns (scWETH.ConstructorParams memory) {

--- a/test/scWETH.t.sol
+++ b/test/scWETH.t.sol
@@ -566,6 +566,7 @@ contract scWETHTest is Test {
         vault.harvest();
 
         assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+        assertEq(vault.totalProfit(), 0, "profit must be zero");
 
         _depositToVault(alice, amount);
 
@@ -573,6 +574,7 @@ contract scWETHTest is Test {
         vault.harvest();
 
         assertEq(vault.balanceOf(treasury), 0, "profit must be zero");
+        assertEq(vault.totalProfit(), 0, "profit must be zero");
     }
 
     // harvest should never count new deposits as profit


### PR DESCRIPTION
- [x] in harvest, store `totalInvested` after `_rebalancePosition()` (since it might change during it)
- [x] added unit tests to check for correct behavior
- [x] decrease `totalInvested` on `_withdrawToVault()` (otherwise it doubles on `withdrawToVault()+depositIntoStrategy()`)
- [x] withdraw extra collateral when deleveraging to cover slippage losses. unrealized slippage ends up in vault