### PR TITLE
use existing MockUSDC for goerli instead of new deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Please create a `.env` file before deployment. An example can be found in `.env.
 #### Dryrun
 
 ```
-forge script script/Deploy.s.sol -f [network]
+forge script script/[Script].s.sol --rpc-url [RPC URL]
 ```
 
 ### Live
 
 ```
-forge script script/Deploy.s.sol -f [network] --verify --broadcast
+forge script script/[Script].s.sol --rpc-url [RPC URL] --broadcast --verify
 ```

--- a/script/DeployLeveragedEthLocal.s.sol
+++ b/script/DeployLeveragedEthLocal.s.sol
@@ -15,7 +15,7 @@ contract DeployScript is DeployLeveragedEth, Test {
     address constant alice = address(0x06);
     address constant bob = address(0x07);
 
-    function deployMockTokens () override internal {
+    function deployMockTokens() internal override {
         weth = new MockWETH();
         usdc = new MockUSDC();
     }

--- a/script/DeployLeveragedEthTestnet.s.sol
+++ b/script/DeployLeveragedEthTestnet.s.sol
@@ -100,7 +100,7 @@ contract DeployScript is CREATE3Script {
 
     function deployMocks() internal {
         weth = new MockWETH();
-        usdc = new MockUSDC();
+        usdc = MockUSDC(0x9d5fCB5b31E8Eba24D8A47ed28c94c93e72d98B1);
         aavePool = new MockAavePool();
         aavePoolDataProvider = new MockAavePoolDataProvider(address(usdc), address(weth));
         aaveAUsdc = new MockAUsdc(aavePool, usdc);

--- a/script/DeployLeveragedEthTestnet.s.sol
+++ b/script/DeployLeveragedEthTestnet.s.sol
@@ -10,7 +10,7 @@ import {MockWETH} from "../test/mocks/MockWETH.sol";
 import {MockUSDC} from "../test/mocks/MockUSDC.sol";
 
 contract DeployScript is DeployLeveragedEth {
-    function deployMockTokens () override internal {
+    function deployMockTokens() internal override {
         weth = new MockWETH();
         usdc = MockUSDC(0x30e2B7a907997fDC5a71E377Ece54FAae9F5392D);
     }

--- a/script/DeployLeveragedEthTestnet.s.sol
+++ b/script/DeployLeveragedEthTestnet.s.sol
@@ -100,7 +100,7 @@ contract DeployScript is CREATE3Script {
 
     function deployMocks() internal {
         weth = new MockWETH();
-        usdc = MockUSDC(0x9d5fCB5b31E8Eba24D8A47ed28c94c93e72d98B1);
+        usdc = MockUSDC(0x30e2B7a907997fDC5a71E377Ece54FAae9F5392D);
         aavePool = new MockAavePool();
         aavePoolDataProvider = new MockAavePoolDataProvider(address(usdc), address(weth));
         aaveAUsdc = new MockAUsdc(aavePool, usdc);


### PR DESCRIPTION
- Verified Goerli Deployments README clarification 
- Reuse USDC contract used by other sandclock staging strategies