### PR TITLE
scWETH: check Interest rates and update LTV accordingly

### DIFF
--- a/script/UpdateLtvLeveragedEthMainnet.s.sol
+++ b/script/UpdateLtvLeveragedEthMainnet.s.sol
@@ -16,7 +16,7 @@ contract UpdateLtvLeveragedEthMainnet is Script {
     scWETH vault = scWETH(payable(vm.envAddress("scWETH")));
     IPool aaveV3Pool = IPool(C.AAVE_V3_POOL);
 
-    uint256 bestLtv = 0.8e18;
+    uint256 bestLtv = 0.85e18;
     uint256 lowestLtv = 1e8;
 
     function run() external {

--- a/script/UpdateLtvLeveragedEthMainnet.s.sol
+++ b/script/UpdateLtvLeveragedEthMainnet.s.sol
@@ -36,11 +36,13 @@ contract UpdateLtvLeveragedEthMainnet is Script {
             vault.harvest();
 
             console.log("Applied new Target Ltv", lowestLtv);
-        } else {
-            if (vault.getLtv() < bestLtv) {
-                vault.applyNewTargetLtv(bestLtv);
-                console.log("Applied new Target Ltv", bestLtv);
-            }
+            
+            return;
+        }
+       
+        if (vault.getLtv() < bestLtv) {
+            vault.applyNewTargetLtv(bestLtv);
+            console.log("Applied new Target Ltv", bestLtv);
         }
     }
 }

--- a/script/UpdateLtvLeveragedEthMainnet.s.sol
+++ b/script/UpdateLtvLeveragedEthMainnet.s.sol
@@ -36,10 +36,10 @@ contract UpdateLtvLeveragedEthMainnet is Script {
             vault.harvest();
 
             console.log("Applied new Target Ltv", lowestLtv);
-            
+
             return;
         }
-       
+
         if (vault.getLtv() < bestLtv) {
             vault.applyNewTargetLtv(bestLtv);
             console.log("Applied new Target Ltv", bestLtv);

--- a/script/UpdateLtvLeveragedEthMainnet.s.sol
+++ b/script/UpdateLtvLeveragedEthMainnet.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.13;
+
+import {scWETH} from "../src/steth/scWETH.sol";
+import {IPool} from "aave-v3/interfaces/IPool.sol";
+import {Constants as C} from "../src/lib/Constants.sol";
+import {DataTypes} from "aave-v3/protocol/libraries/types/DataTypes.sol";
+import {WadRayMath} from "aave-v3/protocol/libraries/math/WadRayMath.sol";
+
+import "forge-std/Script.sol";
+
+contract UpdateLtvLeveragedEthMainnet is Script {
+    using WadRayMath for uint128;
+
+    address keeper = vm.envAddress("KEEPER");
+    scWETH vault = scWETH(payable(vm.envAddress("scWETH")));
+    IPool aaveV3Pool = IPool(C.AAVE_V3_POOL);
+
+    uint256 bestLtv = 0.8e18;
+    uint256 lowestLtv = 1e8;
+
+    function run() external {
+        // get Lido Interest (with 18 decimals)
+        uint256 lidoInterest = 0; // TODO
+
+        // get AaveV3 borrow rate
+        DataTypes.ReserveData memory reserveData = aaveV3Pool.getReserveData(C.WETH);
+        // (with 18 decimals)
+        uint256 borrowInterest = reserveData.currentVariableBorrowRate.rayToWad();
+
+        console.log("Borrow Interest", borrowInterest);
+        console.log("Lido Interest", lidoInterest);
+
+        if (borrowInterest > lidoInterest) {
+            vault.applyNewTargetLtv(lowestLtv);
+            vault.harvest();
+        } else {
+            if (vault.getLtv() < bestLtv) {
+                vault.applyNewTargetLtv(bestLtv);
+            }
+        }
+    }
+}

--- a/script/UpdateLtvLeveragedEthMainnet.s.sol
+++ b/script/UpdateLtvLeveragedEthMainnet.s.sol
@@ -34,9 +34,12 @@ contract UpdateLtvLeveragedEthMainnet is Script {
         if (borrowInterest > lidoInterest) {
             vault.applyNewTargetLtv(lowestLtv);
             vault.harvest();
+
+            console.log("Applied new Target Ltv", lowestLtv);
         } else {
             if (vault.getLtv() < bestLtv) {
                 vault.applyNewTargetLtv(bestLtv);
+                console.log("Applied new Target Ltv", bestLtv);
             }
         }
     }

--- a/test/scWETH.t.sol
+++ b/test/scWETH.t.sol
@@ -746,14 +746,14 @@ contract scWETHTest is Test {
     }
 
     function test_invest_at_almostZeroLtv(uint256 amount) public {
-        amount = bound(amount, 1e18, 1e20);
-        vault.setTreasury(treasury);
+        amount = bound(amount, 1 ether, 1000 ether);
+        uint256 lowestLtv = 1e8;
 
         _depositToVault(address(this), amount);
 
         vm.startPrank(keeper);
         vault.harvest();
-        vault.applyNewTargetLtv(1e8);
+        vault.applyNewTargetLtv(lowestLtv);
         vault.harvest();
 
         assertEq(weth.balanceOf(address(vault)), 0, "there is float in the vault");


### PR DESCRIPTION
Added a script which:

- Queries for the Lido Staking Interest (lr) and AAVE v3 borrow interest (br)
- if br>lr, update ltv to a very low number (almost zero), which is similar to taking no leverage and depositing everything to Lido
- else checks if the ltv is less than the best ltv and updates the ltv if true. This logic will be hit in the scenario where we reduced the ltv to almost zero and then after few days if the lr is greater than the br again.