### PR TITLE
address lido stake rate limit scenario

### DIFF
--- a/src/steth/Swapper.sol
+++ b/src/steth/Swapper.sol
@@ -16,6 +16,8 @@ import {Constants as C} from "../lib/Constants.sol";
 /**
  * @title Swapper
  * @notice Contract facilitating token swaps on Uniswap V3 and 0x.
+ * @dev This contract is only meant to be used via delegatecalls from another contract.
+ * @dev Using this contract directly for swaps might result in reverts.
  */
 contract Swapper {
     using SafeTransferLib for ERC20;

--- a/src/steth/scWETHv2.sol
+++ b/src/steth/scWETHv2.sol
@@ -103,7 +103,8 @@ contract scWETHv2 is BaseV2Vault {
     }
 
     /// @notice swap weth to wstEth
-    /// @dev mainly to be used in the multicall to swap borrowed weth to wstEth for supplying to the lending markets
+    /// @dev the keeper will mostly used 0x (zeroExSwap method) for swapping weth to wstEth between rebalancing
+    /// @dev this method is just a precaution and to be only used by the keeper in case zeroEx API goes down
     /// @param _wethAmount amount of weth to be swapped to wstEth
     function swapWethToWstEth(uint256 _wethAmount) external {
         _onlyKeeperOrFlashLoan();

--- a/src/steth/scWETHv2.sol
+++ b/src/steth/scWETHv2.sol
@@ -103,7 +103,7 @@ contract scWETHv2 is BaseV2Vault {
     }
 
     /// @notice swap weth to wstEth
-    /// @dev the keeper will mostly used 0x (zeroExSwap method) for swapping weth to wstEth between rebalancing
+    /// @dev the keeper will mostly use 0x (zeroExSwap method) for swapping weth to wstEth between rebalancing
     /// @dev this method is just a precaution and to be only used by the keeper in case zeroEx API goes down
     /// @param _wethAmount amount of weth to be swapped to wstEth
     function swapWethToWstEth(uint256 _wethAmount) external {


### PR DESCRIPTION
Documentation for the TOB issues:

- Lido stake rate limit could lead to unexpected reverts  ( We will be using 0x for the weth to wstEth swaps so even during a lido stake limit scenario we dont have to worry because 0x will automatically use curve for the swap in such a scenario)
- Document Swapper contract usage requirements