### PR TITLE
[TOB-SANDCLOCK-6] use Liquity USD/ETH oracle (chainlink + tellor backup)

### DIFF
--- a/src/interfaces/liquity/IPriceFeed.sol
+++ b/src/interfaces/liquity/IPriceFeed.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.8.10;
+
+interface IPriceFeed {
+    // --- Events ---
+    event LastGoodPriceUpdated(uint256 _lastGoodPrice);
+
+    // --- Function ---
+    function fetchPrice() external returns (uint256);
+
+    function lastGoodPrice() external view returns (uint256);
+}

--- a/src/lib/Constants.sol
+++ b/src/lib/Constants.sol
@@ -64,8 +64,8 @@ library Constants {
     address public constant CHAINLINK_USDC_ETH_PRICE_FEED = 0x986b5E1e1755e3C2440e960477f25201B0a8bbD4;
     // Chainlink pricefeed (stETH -> ETH)
     address public constant CHAINLINK_STETH_ETH_PRICE_FEED = 0x86392dC19c0b719886221c78AB11eb8Cf5c52812;
-    // Liquity pricefeed (LUSD -> ETH) with Chainlink as primary and Tellor as backup.
-    address public constant LIQUITY_LUSD_ETH_PRICE_FEED = 0x4c517D4e2C851CA76d7eC94B805269Df0f2201De;
+    // Liquity pricefeed (USD -> ETH) with Chainlink as primary and Tellor as backup.
+    address public constant LIQUITY_USD_ETH_PRICE_FEED = 0x4c517D4e2C851CA76d7eC94B805269Df0f2201De;
 
     // address of the Balancer vault contract
     address public constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;

--- a/src/lib/Constants.sol
+++ b/src/lib/Constants.sol
@@ -64,8 +64,8 @@ library Constants {
     address public constant CHAINLINK_USDC_ETH_PRICE_FEED = 0x986b5E1e1755e3C2440e960477f25201B0a8bbD4;
     // Chainlink pricefeed (stETH -> ETH)
     address public constant CHAINLINK_STETH_ETH_PRICE_FEED = 0x86392dC19c0b719886221c78AB11eb8Cf5c52812;
-    // Chainlink pricefeed (stETH -> USD)
-    address public constant CHAINLINK_LUSD_ETH_PRICE_FEED = 0x60c0b047133f696334a2b7f68af0b49d2F3D4F72;
+    // Liquity pricefeed (LUSD -> ETH) with Chainlink as primary and Tellor as backup.
+    address public constant LIQUITY_LUSD_ETH_PRICE_FEED = 0x4c517D4e2C851CA76d7eC94B805269Df0f2201De;
 
     // address of the Balancer vault contract
     address public constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;

--- a/src/liquity/scLiquity.sol
+++ b/src/liquity/scLiquity.sol
@@ -7,7 +7,7 @@ import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 import {Constants as C} from "../lib/Constants.sol";
 import {IStabilityPool} from "../interfaces/liquity/IStabilityPool.sol";
-import {IPriceFeed} from "../interfaces/chainlink/IPriceFeed.sol";
+import {IPriceFeed} from "../interfaces/liquity/IPriceFeed.sol";
 import {sc4626} from "../sc4626.sol";
 
 contract scLiquity is sc4626 {
@@ -23,7 +23,7 @@ contract scLiquity is sc4626 {
     uint256 public totalProfit;
 
     IStabilityPool public stabilityPool = IStabilityPool(C.LIQUITY_STABILITY_POOL);
-    IPriceFeed public lusd2eth = IPriceFeed(C.CHAINLINK_LUSD_ETH_PRICE_FEED);
+    IPriceFeed public lusd2eth = IPriceFeed(C.LIQUITY_LUSD_ETH_PRICE_FEED);
     ERC20 public lqty = ERC20(C.LIQUITY_LQTY_TOKEN);
 
     // 0x swap router
@@ -46,8 +46,8 @@ contract scLiquity is sc4626 {
     function totalAssets() public view override returns (uint256 assets) {
         uint256 ethBalance = address(this).balance + stabilityPool.getDepositorETHGain(address(this));
 
-        // add eth balance in lusd terms using chainlink oracle
-        assets = ethBalance.mulWadDown(uint256(lusd2eth.latestAnswer()));
+        // add eth balance in lusd terms using liquity oracle
+        assets = ethBalance.mulWadDown(uint256(lusd2eth.lastGoodPrice()));
 
         // add float
         assets += asset.balanceOf(address(this));

--- a/src/liquity/scLiquity.sol
+++ b/src/liquity/scLiquity.sol
@@ -23,7 +23,7 @@ contract scLiquity is sc4626 {
     uint256 public totalProfit;
 
     IStabilityPool public stabilityPool = IStabilityPool(C.LIQUITY_STABILITY_POOL);
-    IPriceFeed public lusd2eth = IPriceFeed(C.LIQUITY_LUSD_ETH_PRICE_FEED);
+    IPriceFeed public lusd2eth = IPriceFeed(C.LIQUITY_USD_ETH_PRICE_FEED);
     ERC20 public lqty = ERC20(C.LIQUITY_LQTY_TOKEN);
 
     // 0x swap router
@@ -47,7 +47,7 @@ contract scLiquity is sc4626 {
         uint256 ethBalance = address(this).balance + stabilityPool.getDepositorETHGain(address(this));
 
         // add eth balance in lusd terms using liquity oracle
-        assets = ethBalance.mulWadDown(uint256(lusd2eth.lastGoodPrice()));
+        assets = ethBalance.mulWadDown(uint256(usd2eth.lastGoodPrice()));
 
         // add float
         assets += asset.balanceOf(address(this));

--- a/src/liquity/scLiquity.sol
+++ b/src/liquity/scLiquity.sol
@@ -23,7 +23,7 @@ contract scLiquity is sc4626 {
     uint256 public totalProfit;
 
     IStabilityPool public stabilityPool = IStabilityPool(C.LIQUITY_STABILITY_POOL);
-    IPriceFeed public lusd2eth = IPriceFeed(C.LIQUITY_USD_ETH_PRICE_FEED);
+    IPriceFeed public usd2eth = IPriceFeed(C.LIQUITY_USD_ETH_PRICE_FEED);
     ERC20 public lqty = ERC20(C.LIQUITY_LQTY_TOKEN);
 
     // 0x swap router

--- a/test/mocks/liquity/MockPriceFeed.sol
+++ b/test/mocks/liquity/MockPriceFeed.sol
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.8.10;
 
-import {IPriceFeed} from "../../../src/interfaces/chainlink/IPriceFeed.sol";
+import {IPriceFeed} from "../../../src/interfaces/liquity/IPriceFeed.sol";
 
 contract MockPriceFeed is IPriceFeed {
     string public constant NAME = "PriceFeed";
 
-    int256 public lastGoodPrice;
+    uint256 public price;
 
-    function latestAnswer() external view override returns (int256) {
-        return lastGoodPrice;
+    function lastGoodPrice() external view override returns (uint256) {
+        return price;
     }
 
-    function setPrice(uint256 price) external {
-        lastGoodPrice = int256(price);
+    function fetchPrice() external view override returns (uint256) {
+        return price;
+    }
+
+    function setPrice(uint256 _price) external {
+        price = _price;
     }
 }

--- a/test/scLiquity.t.sol
+++ b/test/scLiquity.t.sol
@@ -21,7 +21,7 @@ contract MockVault is Vault {
         address _xrouter
     ) Vault(_admin, _keeper, _lusd) {
         stabilityPool = _stabilityPool;
-        lusd2eth = _priceFeed;
+        usd2eth = _priceFeed;
         lqty = _lqty;
         xrouter = _xrouter;
         asset.approve(address(stabilityPool), type(uint256).max);
@@ -37,7 +37,7 @@ contract SandclockLUSDTest is DSTestPlus {
     MockVault vault;
     MockStabilityPool stabilityPool;
     MockLiquityPriceFeed priceFeed;
-    MockPriceFeed lusd2eth;
+    MockPriceFeed usd2eth;
 
     function setUp() public {
         underlying = new MockERC20("Mock LUSD", "LUSD", 18);
@@ -45,9 +45,9 @@ contract SandclockLUSDTest is DSTestPlus {
         xrouter = new Mock0x();
         priceFeed = new MockLiquityPriceFeed();
         stabilityPool = new MockStabilityPool(address(underlying), address(lqty), address(priceFeed));
-        lusd2eth = new MockPriceFeed();
-        lusd2eth.setPrice(935490589304841);
-        vault = new MockVault(address(this), address(this), underlying, stabilityPool, lusd2eth, lqty, address(xrouter));
+        usd2eth = new MockPriceFeed();
+        usd2eth.setPrice(935490589304841);
+        vault = new MockVault(address(this), address(this), underlying, stabilityPool, usd2eth, lqty, address(xrouter));
         vault.grantRole(vault.KEEPER_ROLE(), address(this));
     }
 


### PR DESCRIPTION
## Description
The LUSD/ETH price feed used by the scLiquity vault is an intermediate contract that calls depricated latestAnswer methods on upstream chainlink oracles. It also connects to upgradable proxie pricefeeds with unclear owners.

## Solution
Instead of the intermediate contract use the [Liquity USD->ETH oracle](https://etherscan.io/address/0x4c517d4e2c851ca76d7ec94b805269df0f2201de/) which uses Chainlink USD->ETH as a primary and Tellor USD->ETH as a backup and has extra safety checks. Disregard LUSD peg and estimate ETH holdings at LUSD/USD 1:1.

### Side-effects
This means we estimate the ETH holdings to be worth as many LUSD as it is worth USD (as if LUSD is pegged 1:1), disregarding current market value/peg of LUSD. If LUSD trades at less than USD we would overestimate the total assets and users could redeem at a slight advantage until the keeper sells the ETH for LUSD. If the LUSD trades above the dollar then we would under-report the total holdings until the keeper rebalances into LUSD. 

Since ETH is to be traded into LUSD asap and ETH total would only be a small temporary portion of the total holdings this is an OK compromise. Depending on the Liquity USD->ETH oracle is preferable to the previous intermediate contract that connects to upgradable proxies with unknown owners.

### Previous Liquity oracle bug
Because of the complexity in the dual-oracle Liquity design there was a [bug](https://www.liquity.org/blog/tellor-issue-and-fix) in the Tellor fallback functionality. However it has been fixed. Using the same oracle for scLUSD as is used for LUSD makes sense and a bug in LUSD or its oracle cannot be avoided anyways.

## Rundown on different oracles
![2023-07-25-190302_1279x763_scrot](https://github.com/lindy-labs/sandclock-contracts/assets/8256597/858025c0-97db-4538-b4ca-94fcc2945fd6)
