### PR TITLE
ZeroExSwap for weth to wstEth swaps by updating BaseV2Vault code

### DIFF
--- a/src/errors/scErrors.sol
+++ b/src/errors/scErrors.sol
@@ -21,4 +21,4 @@ error FlashLoanAmountZero();
 error ProtocolNotSupported(uint256 adapterId);
 error ProtocolInUse(uint256 adapterId);
 error FloatBalanceTooLow(uint256 actual, uint256 required);
-error InvalidOutToken();
+error TokenNotAllowed(address token);

--- a/src/errors/scErrors.sol
+++ b/src/errors/scErrors.sol
@@ -21,4 +21,4 @@ error FlashLoanAmountZero();
 error ProtocolNotSupported(uint256 adapterId);
 error ProtocolInUse(uint256 adapterId);
 error FloatBalanceTooLow(uint256 actual, uint256 required);
-error TokenNotAllowed(address token);
+error TokenOutNotAllowed(address token);

--- a/src/errors/scErrors.sol
+++ b/src/errors/scErrors.sol
@@ -21,3 +21,4 @@ error FlashLoanAmountZero();
 error ProtocolNotSupported(uint256 adapterId);
 error ProtocolInUse(uint256 adapterId);
 error FloatBalanceTooLow(uint256 actual, uint256 required);
+error InvalidOutToken();

--- a/src/steth/BaseV2Vault.sol
+++ b/src/steth/BaseV2Vault.sol
@@ -141,6 +141,13 @@ abstract contract BaseV2Vault is sc4626, IFlashLoanRecipient {
     }
 
     /**
+     * @notice returns whether a token is whitelisted to be swapped out using zeroExSwap or not
+     */
+    function isTokenWhitelisted(ERC20 _token) external view returns (bool) {
+        return zeroExSwapWhitelist[_token];
+    }
+
+    /**
      * @notice Claim rewards from a lending market.
      * @param _adapterId The ID of the lending market adapter.
      * @param _callData The encoded data for the claimRewards function.

--- a/src/steth/BaseV2Vault.sol
+++ b/src/steth/BaseV2Vault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
-import {TokenNotAllowed} from "../errors/scErrors.sol";
+import {TokenOutNotAllowed} from "../errors/scErrors.sol";
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
@@ -178,7 +178,7 @@ abstract contract BaseV2Vault is sc4626, IFlashLoanRecipient {
     ) external {
         _onlyKeeperOrFlashLoan();
 
-        if (!zeroExSwapWhitelist[_tokenOut]) revert TokenNotAllowed(address(_tokenOut));
+        if (!zeroExSwapWhitelist[_tokenOut]) revert TokenOutNotAllowed(address(_tokenOut));
 
         bytes memory result = address(swapper).functionDelegateCall(
             abi.encodeWithSelector(

--- a/src/steth/BaseV2Vault.sol
+++ b/src/steth/BaseV2Vault.sol
@@ -133,19 +133,28 @@ abstract contract BaseV2Vault is sc4626, IFlashLoanRecipient {
 
     /**
      * @notice Sell any token for the "asset" token on 0x exchange.
-     * @param _token The token to sell.
+     * @param _tokenIn The token to sell.
+     * @param _tokenOut The token to buy.
      * @param _amount The amount of tokens to sell.
      * @param _swapData The swap data for 0xrouter.
      * @param _assetAmountOutMin The minimum amount of "asset" token to receive for the swap.
      */
-    function zeroExSwap(ERC20 _token, uint256 _amount, bytes calldata _swapData, uint256 _assetAmountOutMin) external {
+    function zeroExSwap(
+        ERC20 _tokenIn,
+        ERC20 _tokenOut,
+        uint256 _amount,
+        bytes calldata _swapData,
+        uint256 _assetAmountOutMin
+    ) external {
         _onlyKeeperOrFlashLoan();
 
         bytes memory result = address(swapper).functionDelegateCall(
-            abi.encodeWithSelector(Swapper.zeroExSwap.selector, _token, asset, _amount, _assetAmountOutMin, _swapData)
+            abi.encodeWithSelector(
+                Swapper.zeroExSwap.selector, _tokenIn, _tokenOut, _amount, _assetAmountOutMin, _swapData
+            )
         );
 
-        emit TokenSwapped(address(_token), _amount, abi.decode(result, (uint256)));
+        emit TokenSwapped(address(_tokenIn), _amount, abi.decode(result, (uint256)));
     }
 
     function _multiCall(bytes[] memory _callData) internal {

--- a/src/steth/BaseV2Vault.sol
+++ b/src/steth/BaseV2Vault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
-import {InvalidOutToken} from "../errors/scErrors.sol";
+import {TokenNotAllowed} from "../errors/scErrors.sol";
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {Address} from "openzeppelin-contracts/utils/Address.sol";
@@ -178,7 +178,7 @@ abstract contract BaseV2Vault is sc4626, IFlashLoanRecipient {
     ) external {
         _onlyKeeperOrFlashLoan();
 
-        if (!zeroExSwapWhitelist[_tokenOut]) revert InvalidOutToken();
+        if (!zeroExSwapWhitelist[_tokenOut]) revert TokenNotAllowed(address(_tokenOut));
 
         bytes memory result = address(swapper).functionDelegateCall(
             abi.encodeWithSelector(

--- a/src/steth/scWETHv2.sol
+++ b/src/steth/scWETHv2.sol
@@ -60,7 +60,9 @@ contract scWETHv2 is BaseV2Vault {
 
     constructor(address _admin, address _keeper, WETH _weth, Swapper _swapper, PriceConverter _priceConverter)
         BaseV2Vault(_admin, _keeper, _weth, _priceConverter, _swapper, "Sandclock WETH Vault v2", "scWETHv2")
-    {}
+    {
+        zeroExSwapWhitelist[ERC20(C.WSTETH)] = true;
+    }
 
     /*//////////////////////////////////////////////////////////////
                             PUBLIC API

--- a/test/scUSDCv2.t.sol
+++ b/test/scUSDCv2.t.sol
@@ -1944,7 +1944,7 @@ contract scUSDCv2Test is Test {
         _setUpForkAtBlock(EUL_SWAP_BLOCK);
         vm.startPrank(alice);
         vm.expectRevert(CallerNotKeeper.selector);
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), 0, bytes("0"), 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.USDC), 0, bytes("0"), 0);
     }
 
     function test_zeroExSwap_SwapsEulerForUsdc() public {
@@ -1958,7 +1958,7 @@ contract scUSDCv2Test is Test {
         assertEq(vault.usdcBalance(), initialUsdcBalance, "usdc balance");
         assertEq(vault.totalAssets(), initialUsdcBalance, "total assets");
 
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.USDC), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED);
 
         assertEq(ERC20(C.EULER_REWARDS_TOKEN).balanceOf(address(vault)), EUL_AMOUNT, "euler end balance");
         assertEq(vault.totalAssets(), initialUsdcBalance + EUL_SWAP_USDC_RECEIVED, "vault total assets");
@@ -1974,7 +1974,7 @@ contract scUSDCv2Test is Test {
         vm.expectEmit(true, true, true, true);
         emit TokenSwapped(C.EULER_REWARDS_TOKEN, EUL_AMOUNT, EUL_SWAP_USDC_RECEIVED);
 
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, EUL_SWAP_DATA, 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.USDC), EUL_AMOUNT, EUL_SWAP_DATA, 0);
     }
 
     function test_zeroExSwap_FailsIfUsdcAmountReceivedIsLessThanMin() public {
@@ -1984,7 +1984,7 @@ contract scUSDCv2Test is Test {
 
         vm.expectRevert(AmountReceivedBelowMin.selector);
         vault.zeroExSwap(
-            ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED + 1
+            ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.USDC), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED + 1
         );
     }
 
@@ -1996,7 +1996,7 @@ contract scUSDCv2Test is Test {
         bytes memory invalidSwapData = hex"6af479b20000";
 
         vm.expectRevert("Address: low-level call failed");
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, invalidSwapData, 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.USDC), EUL_AMOUNT, invalidSwapData, 0);
     }
 
     /// #claimRewards ///

--- a/test/scUSDCv2.t.sol
+++ b/test/scUSDCv2.t.sol
@@ -1944,7 +1944,7 @@ contract scUSDCv2Test is Test {
         _setUpForkAtBlock(EUL_SWAP_BLOCK);
         vm.startPrank(alice);
         vm.expectRevert(CallerNotKeeper.selector);
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), 0, bytes("0"), 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), 0, bytes("0"), 0);
     }
 
     function test_zeroExSwap_SwapsEulerForUsdc() public {
@@ -1958,7 +1958,7 @@ contract scUSDCv2Test is Test {
         assertEq(vault.usdcBalance(), initialUsdcBalance, "usdc balance");
         assertEq(vault.totalAssets(), initialUsdcBalance, "total assets");
 
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED);
 
         assertEq(ERC20(C.EULER_REWARDS_TOKEN).balanceOf(address(vault)), EUL_AMOUNT, "euler end balance");
         assertEq(vault.totalAssets(), initialUsdcBalance + EUL_SWAP_USDC_RECEIVED, "vault total assets");
@@ -1974,7 +1974,7 @@ contract scUSDCv2Test is Test {
         vm.expectEmit(true, true, true, true);
         emit TokenSwapped(C.EULER_REWARDS_TOKEN, EUL_AMOUNT, EUL_SWAP_USDC_RECEIVED);
 
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), EUL_AMOUNT, EUL_SWAP_DATA, 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, EUL_SWAP_DATA, 0);
     }
 
     function test_zeroExSwap_FailsIfUsdcAmountReceivedIsLessThanMin() public {
@@ -1983,7 +1983,9 @@ contract scUSDCv2Test is Test {
         deal(C.EULER_REWARDS_TOKEN, address(vault), EUL_AMOUNT);
 
         vm.expectRevert(AmountReceivedBelowMin.selector);
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED + 1);
+        vault.zeroExSwap(
+            ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, EUL_SWAP_DATA, EUL_SWAP_USDC_RECEIVED + 1
+        );
     }
 
     function test_zeroExSwap_FailsIfSwapIsNotSucessful() public {
@@ -1994,7 +1996,7 @@ contract scUSDCv2Test is Test {
         bytes memory invalidSwapData = hex"6af479b20000";
 
         vm.expectRevert("Address: low-level call failed");
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), EUL_AMOUNT, invalidSwapData, 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), EUL_AMOUNT, invalidSwapData, 0);
     }
 
     /// #claimRewards ///

--- a/test/scWETHv2.t.sol
+++ b/test/scWETHv2.t.sol
@@ -139,6 +139,34 @@ contract scWETHv2Test is Test {
         assertEq(address(vault.balancerVault()), C.BALANCER_VAULT);
     }
 
+    function test_whiteListOutToken() public {
+        _setUp(BLOCK_AFTER_EULER_EXPLOIT);
+        assertEq(vault.isTokenWhitelisted(vault.asset()), true, "Asset token not whitelisted");
+        assertEq(vault.isTokenWhitelisted(ERC20(C.WSTETH)), true, "WstEth token not whitelisted");
+
+        vm.expectRevert(CallerNotAdmin.selector);
+        vm.prank(alice);
+        vault.whiteListOutToken(ERC20(C.USDC), true);
+
+        assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), false);
+
+        vault.whiteListOutToken(ERC20(C.USDC), true);
+        assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), true);
+
+        vault.whiteListOutToken(ERC20(C.USDC), false);
+        assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), false);
+    }
+
+    function test_zeroExSwap_InvalidOutToken() public {
+        _setUp(BLOCK_AFTER_EULER_EXPLOIT);
+        uint256 amount = 10 ether;
+        _depositToVault(address(this), amount);
+
+        vm.expectRevert(InvalidOutToken.selector);
+        hoax(keeper);
+        vault.zeroExSwap(weth, ERC20(C.USDC), amount, "", 0);
+    }
+
     function test_addAdapter() public {
         _setUp(BLOCK_AFTER_EULER_EXPLOIT);
 

--- a/test/scWETHv2.t.sol
+++ b/test/scWETHv2.t.sol
@@ -158,12 +158,12 @@ contract scWETHv2Test is Test {
         assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), false);
     }
 
-    function test_zeroExSwap_TokenNotAllowed() public {
+    function test_zeroExSwap_TokenOutNotAllowed() public {
         _setUp(BLOCK_AFTER_EULER_EXPLOIT);
         uint256 amount = 10 ether;
         _depositToVault(address(this), amount);
 
-        vm.expectRevert(abi.encodeWithSelector(TokenNotAllowed.selector, C.USDC));
+        vm.expectRevert(abi.encodeWithSelector(TokenOutNotAllowed.selector, C.USDC));
         hoax(keeper);
         vault.zeroExSwap(weth, ERC20(C.USDC), amount, "", 0);
     }

--- a/test/scWETHv2.t.sol
+++ b/test/scWETHv2.t.sol
@@ -1174,7 +1174,9 @@ contract scWETHv2Test is Test {
 
         bytes[] memory callData = new bytes[](3);
 
-        callData[0] = abi.encodeWithSelector(BaseV2Vault.zeroExSwap.selector, weth, wstEth, investAmount + totalFlashLoanAmount, swapData, 1);
+        callData[0] = abi.encodeWithSelector(
+            BaseV2Vault.zeroExSwap.selector, weth, wstEth, investAmount + totalFlashLoanAmount, swapData, 1
+        );
 
         callData[1] = abi.encodeWithSelector(
             scWETHv2.supplyAndBorrow.selector,

--- a/test/scWETHv2.t.sol
+++ b/test/scWETHv2.t.sol
@@ -148,7 +148,8 @@ contract scWETHv2Test is Test {
         vm.prank(alice);
         vault.whiteListOutToken(ERC20(C.USDC), true);
 
-        assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), false);
+        vm.expectRevert(ZeroAddress.selector);
+        vault.whiteListOutToken(ERC20(address(0x00)), true);
 
         vault.whiteListOutToken(ERC20(C.USDC), true);
         assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), true);
@@ -157,12 +158,12 @@ contract scWETHv2Test is Test {
         assertEq(vault.isTokenWhitelisted(ERC20(C.USDC)), false);
     }
 
-    function test_zeroExSwap_InvalidOutToken() public {
+    function test_zeroExSwap_TokenNotAllowed() public {
         _setUp(BLOCK_AFTER_EULER_EXPLOIT);
         uint256 amount = 10 ether;
         _depositToVault(address(this), amount);
 
-        vm.expectRevert(InvalidOutToken.selector);
+        vm.expectRevert(abi.encodeWithSelector(TokenNotAllowed.selector, C.USDC));
         hoax(keeper);
         vault.zeroExSwap(weth, ERC20(C.USDC), amount, "", 0);
     }

--- a/test/scWETHv2.t.sol
+++ b/test/scWETHv2.t.sol
@@ -303,10 +303,10 @@ contract scWETHv2Test is Test {
         deal(C.EULER_REWARDS_TOKEN, address(vault), eulerAmount);
 
         vm.expectRevert(CallerNotKeeper.selector);
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), eulerAmount, swapData, 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), eulerAmount, swapData, 0);
 
         hoax(keeper);
-        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), eulerAmount, swapData, 0);
+        vault.zeroExSwap(ERC20(C.EULER_REWARDS_TOKEN), ERC20(C.WETH), eulerAmount, swapData, 0);
 
         assertGe(weth.balanceOf(address(vault)), expectedWethAmount, "weth not received");
         assertEq(ERC20(C.EULER_REWARDS_TOKEN).balanceOf(address(vault)), 0, "euler token not transferred out");
@@ -322,7 +322,7 @@ contract scWETHv2Test is Test {
 
         deal(address(wstEth), address(vault), wstEthAmount);
         vm.prank(keeper);
-        vault.zeroExSwap(ERC20(address(wstEth)), wstEthAmount, swapData, 0);
+        vault.zeroExSwap(ERC20(address(wstEth)), ERC20(C.WETH), wstEthAmount, swapData, 0);
 
         assertGe(weth.balanceOf(address(vault)), expectedWethAmount, "weth not received");
         assertEq(wstEth.balanceOf(address(vault)), 0, "wstEth not transferred out");
@@ -666,8 +666,9 @@ contract scWETHv2Test is Test {
         );
 
         // swap wstEth to weth using zeroEx swap
-        callData[1] =
-            abi.encodeWithSelector(BaseV2Vault.zeroExSwap.selector, wstEth, wstEthAmountToWithdraw, swapData, 0);
+        callData[1] = abi.encodeWithSelector(
+            BaseV2Vault.zeroExSwap.selector, wstEth, ERC20(C.WETH), wstEthAmountToWithdraw, swapData, 0
+        );
 
         hoax(keeper);
         vault.rebalance(0, expectedWethAmountAfterSwap, callData);
@@ -1144,6 +1145,64 @@ contract scWETHv2Test is Test {
         assertApproxEqRel(balance, profit.mulWadDown(vault.performanceFee()), 0.015e18);
     }
 
+    function test_invest_withZeroExWethToWstEthSwap() public {
+        _setUp(17934941);
+
+        bytes memory swapData =
+            hex"6af479b20000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000011e3ab8395c6e8000000000000000000000000000000000000000000000000000f97a7ede4f09e7a5b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002bc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000647f39c581f595b53c5cb19bd0b3f8da6c935e2ca0000000000000000000000000000000000000000000869584cd000000000000000000000000588ebf90cce940403c2d3650519313ed5c414cc200000000000000000000000000000000095789faafab13e98e0d8e807cdbbddf";
+
+        vault.setTreasury(treasury);
+        uint256 amount = 100 ether;
+        _depositToVault(address(this), amount);
+
+        uint256 investAmount = amount - minimumFloatAmount;
+
+        uint256 stEthRateTolerance = 0.999e18;
+
+        uint256 aaveV3Amount = investAmount.mulWadDown(0.5e18);
+        uint256 compoundAmount = investAmount.mulWadDown(0.5e18);
+
+        uint256 aaveV3FlashLoanAmount = _calcSupplyBorrowFlashLoanAmount(aaveV3Adapter, aaveV3Amount);
+        uint256 compoundFlashLoanAmount = _calcSupplyBorrowFlashLoanAmount(compoundV3Adapter, compoundAmount);
+
+        uint256 aaveV3SupplyAmount =
+            priceConverter.ethToWstEth(aaveV3Amount + aaveV3FlashLoanAmount).mulWadDown(stEthRateTolerance);
+        uint256 compoundSupplyAmount =
+            priceConverter.ethToWstEth(compoundAmount + compoundFlashLoanAmount).mulWadDown(stEthRateTolerance);
+
+        uint256 totalFlashLoanAmount = aaveV3FlashLoanAmount + compoundFlashLoanAmount;
+
+        bytes[] memory callData = new bytes[](3);
+
+        callData[0] = abi.encodeWithSelector(BaseV2Vault.zeroExSwap.selector, weth, wstEth, investAmount + totalFlashLoanAmount, swapData, 1);
+
+        callData[1] = abi.encodeWithSelector(
+            scWETHv2.supplyAndBorrow.selector,
+            aaveV3AdapterId,
+            aaveV3SupplyAmount,
+            aaveV3FlashLoanAmount.mulWadUp(1e18 + flashLoanFeePercent)
+        );
+
+        callData[2] = abi.encodeWithSelector(
+            scWETHv2.supplyAndBorrow.selector,
+            compoundV3AdapterId,
+            compoundSupplyAmount,
+            compoundFlashLoanAmount.mulWadUp(1e18 + flashLoanFeePercent)
+        );
+
+        hoax(keeper);
+        vault.rebalance(investAmount, totalFlashLoanAmount, callData);
+
+        _floatCheck();
+        _investChecksWithoutEuler(
+            investAmount,
+            priceConverter.wstEthToEth(aaveV3SupplyAmount + compoundSupplyAmount),
+            totalFlashLoanAmount,
+            0.5e18,
+            0.5e18
+        );
+    }
+
     //////////////////////////// INTERNAL METHODS ////////////////////////////////////////
 
     function _calcSupplyBorrowFlashLoanAmount(IAdapter adapter, uint256 amount)
@@ -1506,6 +1565,53 @@ contract scWETHv2Test is Test {
         );
         assertApproxEqRel(vaultHelper.getLtv(eulerAdapter), targetLtv[eulerAdapter], 0.005e18, "euler ltv not correct");
 
+        assertApproxEqRel(
+            vaultHelper.getLtv(compoundV3Adapter), targetLtv[compoundV3Adapter], 0.005e18, "compound ltv not correct"
+        );
+    }
+
+    function _investChecksWithoutEuler(
+        uint256 amount,
+        uint256 totalSupplyAmount,
+        uint256 totalDebtTaken,
+        uint256 aaveV3Allocation,
+        uint256 compoundAllocation
+    ) internal {
+        uint256 totalCollateral = priceConverter.wstEthToEth(vault.totalCollateral());
+        uint256 totalDebt = vault.totalDebt();
+        assertApproxEqRel(totalCollateral - totalDebt, amount, 0.01e18, "totalAssets not equal amount");
+        assertEq(vault.totalInvested(), amount, "totalInvested not updated");
+        assertApproxEqRel(totalCollateral, totalSupplyAmount, 0.0001e18, "totalCollateral not equal totalSupplyAmount");
+        assertApproxEqRel(totalDebt, totalDebtTaken, 100, "totalDebt not equal totalDebtTaken");
+
+        uint256 aaveV3Deposited = vaultHelper.getCollateralInWeth(aaveV3Adapter) - vault.getDebt(aaveV3Adapter.id());
+        uint256 compoundDeposited =
+            vaultHelper.getCollateralInWeth(compoundV3Adapter) - vault.getDebt(compoundV3Adapter.id());
+
+        assertApproxEqRel(
+            aaveV3Deposited, amount.mulWadDown(aaveV3Allocation), 0.005e18, "aaveV3 allocation not correct"
+        );
+        assertApproxEqRel(
+            compoundDeposited, amount.mulWadDown(compoundAllocation), 0.005e18, "compound allocation not correct"
+        );
+
+        assertApproxEqRel(
+            vaultHelper.allocationPercent(aaveV3Adapter),
+            aaveV3Allocation,
+            0.005e18,
+            "aaveV3 allocationPercent not correct"
+        );
+
+        assertApproxEqRel(
+            vaultHelper.allocationPercent(compoundV3Adapter),
+            compoundAllocation,
+            0.005e18,
+            "compound allocationPercent not correct"
+        );
+
+        assertApproxEqRel(
+            vaultHelper.getLtv(aaveV3Adapter), targetLtv[aaveV3Adapter], 0.005e18, "aaveV3 ltv not correct"
+        );
         assertApproxEqRel(
             vaultHelper.getLtv(compoundV3Adapter), targetLtv[compoundV3Adapter], 0.005e18, "compound ltv not correct"
         );


### PR DESCRIPTION
It was not possible to use zeroExSwap by the backend to swap from weth to wstEth due to certain restrictions within the code created for security purposes. But we need zeroExSwap for weth=>wstEth  for access to better exchange rates.

- Changes to the zeroExSwap method in BaseV2Vault contract. Adding a tokenOut parameter and replacing asset with tokenOut.
- Also added a whitelist for tokenOuts during zeroExSwap for security.