### PR TITLE
update 'exitAllPositions' scUsdcV2

### DIFF
--- a/src/steth/scUSDCv2.sol
+++ b/src/steth/scUSDCv2.sol
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
-import {
-    VaultNotUnderwater,
-    NoProfitsToSell,
-    FlashLoanAmountZero,
-    EndUsdcBalanceTooLow,
-    FloatBalanceTooLow
-} from "../errors/scErrors.sol";
+import {NoProfitsToSell, FlashLoanAmountZero, EndUsdcBalanceTooLow, FloatBalanceTooLow} from "../errors/scErrors.sol";
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {WETH} from "solmate/tokens/WETH.sol";


### PR DESCRIPTION
- changed caller for exitAllPositions from admin to keeper
- removed "underwater" requirement so all positions can be exited anytime 