### PR TITLE
scWETHv2 Rebalance script wstETH dust rebalance

### DIFF
--- a/script/v2/keeper-actions/RebalanceScWethV2.s.sol
+++ b/script/v2/keeper-actions/RebalanceScWethV2.s.sol
@@ -283,7 +283,6 @@ contract RebalanceScWethV2 is Script, scWETHv2Helper {
             if (flashLoanAmount > 0) {
                 // supply the wstEthDust from last rebalance proportionally to each adapter
                 uint256 wstEthDustToSupply = wstEthDust > 0 ? wstEthDust.mulWadDown(allocationPercent(_adapter)) : 0;
-                console2.log("wstEthDust from lat rebaalnce", wstEthDustToSupply);
 
                 uint256 supplyAmount = priceConverter.ethToWstEth(_amount + flashLoanAmount).mulWadDown(
                     stEthRateTolerance

--- a/script/v2/keeper-actions/RebalanceScWethV2.s.sol
+++ b/script/v2/keeper-actions/RebalanceScWethV2.s.sol
@@ -108,7 +108,7 @@ contract RebalanceScWethV2 is Script, scWETHv2Helper {
     constructor() scWETHv2Helper(scWETHv2(payable(MA.SCWETHV2)), PriceConverter(MA.PRICE_CONVERTER)) {}
 
     function run() external {
-        // _logs("-------------------BEFORE REBALANCE-------------------");
+        _logs("-------------------BEFORE REBALANCE-------------------");
 
         _initializeAdapterSettings();
 
@@ -127,7 +127,7 @@ contract RebalanceScWethV2 is Script, scWETHv2Helper {
             vm.stopBroadcast();
         }
 
-        // _logs("-------------------AFTER REBALANCE-------------------");
+        _logs("-------------------AFTER REBALANCE-------------------");
     }
 
     function _initializeAdapterSettings() internal {

--- a/test/script/RebalanceScWethV2.t.sol
+++ b/test/script/RebalanceScWethV2.t.sol
@@ -129,6 +129,7 @@ contract RebalanceScWethV2Test is Test {
         script.setDemoSwapData(swapData); // setting the demo swap data only for the test since the block number is set for the test but zeroEx api returns swapData for the most recent block
 
         script.run();
+
         script = new RebalanceScWethV2TestHarness(); // reset state
 
         uint256 altv = script.getLtv(morphoAdapter);
@@ -492,7 +493,6 @@ contract RebalanceScWethV2Test is Test {
     function testFloatResetsOnRebalance() public {
         uint256 amount = 10 ether;
         vault.deposit{value: amount}(address(this));
-        uint256 investAmount = _investAmount();
         script.run();
 
         _simulate_stEthStakingInterest(365 days, 1.071e18);
@@ -518,7 +518,6 @@ contract RebalanceScWethV2Test is Test {
     function testRevertsIfVaultDoesNotHaveEnoughAssetsForFloat() public {
         uint256 amount = 1.5 ether;
         vault.deposit{value: amount}(address(this));
-        uint256 investAmount = _investAmount();
         script.run();
 
         vault.withdraw(0.8 ether, address(this), address(this));

--- a/test/script/RebalanceScWethV2.t.sol
+++ b/test/script/RebalanceScWethV2.t.sol
@@ -336,7 +336,7 @@ contract RebalanceScWethV2Test is Test {
         script.setMorphoInvestableAmountPercent(0);
 
         // simulate loss in  aave
-        uint256 updatedAaveV3TargetLtv = script.aaveV3TargetLtv() - 0.02e18;
+        uint256 updatedAaveV3TargetLtv = script.aaveV3TargetLtv() - 0.04e18;
 
         script.updateAaveV3TargetLtv(updatedAaveV3TargetLtv);
 
@@ -365,7 +365,7 @@ contract RebalanceScWethV2Test is Test {
         script = new RebalanceScWethV2TestHarness(); // reset script state
 
         // simulate loss in morpho but not crossing disinvest threshold
-        uint256 updatedMorphoTargetLtv = morphoLtv - script.disinvestThreshold();
+        uint256 updatedMorphoTargetLtv = morphoLtv - script.disinvestThreshold() + 0.005e18;
 
         script.updateMorphoTargetLtv(updatedMorphoTargetLtv);
 
@@ -422,7 +422,7 @@ contract RebalanceScWethV2Test is Test {
 
         script = new RebalanceScWethV2TestHarness(); // reset script state
 
-        uint256 updatedAaveTargetLtv = script.aaveV3TargetLtv() - 0.02e18;
+        uint256 updatedAaveTargetLtv = script.aaveV3TargetLtv() - 0.04e18;
 
         // now decrease target ltvs to simulate loss
         script.updateAaveV3TargetLtv(updatedAaveTargetLtv);

--- a/test/script/RebalanceScWethV2.t.sol
+++ b/test/script/RebalanceScWethV2.t.sol
@@ -526,6 +526,32 @@ contract RebalanceScWethV2Test is Test {
         script.run();
     }
 
+    function testWstEthFloatRebalance() public {
+        uint256 amount = 1.5 ether;
+        vault.deposit{value: amount}(address(this));
+
+        script.run();
+
+        uint256 simulatedWstEthDust = 1e18;
+
+        // put some wstEthFloat in the vault
+        hoax(0x0B925eD163218f6662a35e0f0371Ac234f9E9371);
+        ERC20(C.WSTETH).transfer(address(vault), simulatedWstEthDust);
+
+        vault.deposit{value: amount}(address(this));
+
+        assertGe(ERC20(C.WSTETH).balanceOf(address(vault)), simulatedWstEthDust, "wsTETH dust transfer error");
+
+        script = new RebalanceScWethV2TestHarness(); // reset script state
+        script.run();
+
+        assertLt(
+            ERC20(C.WSTETH).balanceOf(address(vault)),
+            simulatedWstEthDust.mulWadDown(0.0002e18),
+            "wstETH dust not being rebalanced"
+        );
+    }
+
     //////////////////////////////////// INTERNAL METHODS ///////////////////////////////////////
 
     function _investAmount() internal view returns (uint256) {


### PR DESCRIPTION
- Invest wstEth dust from last rebalance proportionally to all investable adapters
- Increased the disinvest Threshold to 2.5% which is a more realistic value.
- Also optimised the disinvestThreshold conditional. If allocationPercent was greater than zero than the script would have disinvested anyway for that adapter without caring for the disinvestThreshold. Moved the disinvest threshold check to the flashLoanAmount calculation function to make sure the script only disinvests when disinvestThreshold is crossed.