### PR TITLE
EVM Version Update

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 optimizer_runs = 1000000
 verbosity = 1
 solc = "0.8.21"
+evm_version= "cancun"
 
 [fuzz]
 runs = 256


### PR DESCRIPTION
The scripts were failing with the following error with the old evm version:

<img width="678" alt="Screenshot 2024-10-25 at 8 58 49 AM" src="https://github.com/user-attachments/assets/817d26d6-891c-4a39-ab7d-7464e08ffd40">



This fixes this